### PR TITLE
Serenty-core version upgrading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 ext {
-    serenity_version = "1.1.22-rc.11"
+    serenity_version = "1.1.25-SNAPSHOT"
     serenity_jbehave_version = "1.5.0"
     serenity_cucumber_version = "1.1.2"
 }
@@ -36,7 +36,7 @@ subprojects {
     }
     buildscript {
         ext {
-            serenity_gradle_plugin_version = "1.1.5"
+            serenity_gradle_plugin_version = "1.1.25-SNAPSHOT"
         }
         repositories {
             mavenLocal()


### PR DESCRIPTION
#### Summary of this PR

Upgrade serenity-core version
#### Intended effect

now it is possible to use features from serenity-core 1.1.24
#### How should this be manually tested?

./gradlew build will use 1.1.24 serenity-core
#### Side effects

N/A
#### Documentation

N/A
#### Relevant tickets

N/A
#### Screenshots (if appropriate)

N/A
