### PR TITLE
Updating of serenity core and dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 ext {
-    serenityCoreVersion = "1.1.25-SNAPSHOT"
+    serenityCoreVersion = "1.1.25-rc.5"
     serenityJBehaveVersion = "1.5.0"
-    serenityCucumberVersion = "1.1.2"
+    serenityCucumberVersion = "1.1.3"
 }
 
 task wrapper(type: Wrapper) {
@@ -60,7 +60,7 @@ subprojects {
     }
 
     task subProjectsCopyDeps(type: Copy) {
-        from configurations.runtime
+        from configurations.runtime + configurations.testCompile
         into project.projectDir.path + "/lib"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.parallel=false
+org.gradle.parallel=true


### PR DESCRIPTION
#### Summary of this PR

Updating dependency for using last serenity core
#### Intended effect

Will be used commons-collections:commons-collections:3.2.2 instead of 3.2.1 as in selenium 2.50.1. 
Also junit with version 4.12 will be used. 
#### How should this be manually tested?

N/A
#### Side effects

N/A
#### Documentation

N/A
#### Relevant tickets

N/A
#### Screenshots (if appropriate)

N/A
