### PR TITLE
Updated serenity-core to 1.1.26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 ext {
-    serenityCoreVersion = "1.1.26-rc.1"
+    serenityCoreVersion = "1.1.26"
     serenityJBehaveVersion = "1.6.0"
     serenityCucumberVersion = "1.1.5"
 }


### PR DESCRIPTION
#### Summary of this PR

Updating serenity-core to 1.1.26
#### Intended effect

Current module can work with latest serenity-core
#### How should this be manually tested?

Projects should be able to build with current version of module and 1.1.26 serenity-core
#### Side effects

N/A
#### Documentation

N/A
#### Relevant tickets

N/A
#### Screenshots (if appropriate)

N/A
